### PR TITLE
Feature implementation from commits 5c4fe8b..0b71b32

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 coverage
-pytest==7.1.2
+pytest==7.1.3
 pytest-asyncio==0.19.0
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage
 pytest==7.2.0
-pytest-asyncio==0.20.2
+pytest-asyncio==0.20.3
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0
 codecov==2.1.12

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage
 pytest==7.2.0
-pytest-asyncio==0.20.1
+pytest-asyncio==0.20.2
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0
 codecov==2.1.12

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage
 pytest==7.1.3
-pytest-asyncio==0.19.0
+pytest-asyncio==0.20.1
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0
 codecov==2.1.12

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 coverage
-pytest==7.1.3
+pytest==7.2.0
 pytest-asyncio==0.20.1
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0

--- a/miss_islington/check_run.py
+++ b/miss_islington/check_run.py
@@ -8,7 +8,6 @@ from .status_change import check_ci_status_and_approval
 router = routing.Router()
 
 TITLE_RE = re.compile(r"\[(?P<branch>\d+\.\d+)\].+?(?P<pr>\d+)\)")
-AUTOMERGE_TRAILER = "Automerge-Triggered-By"
 
 
 @router.register("check_run", action="completed")
@@ -19,7 +18,8 @@ async def check_run_completed(event, gh, *args, **kwargs):
     sha = event.data["check_run"]["head_sha"]
 
     if event.data["sender"]["login"] == "miss-islington":
-        await check_ci_status_and_approval(gh, sha, leave_comment=True)
+        # Leave comment temporarily disabled when automerge not used. See #577.
+        await check_ci_status_and_approval(gh, sha, leave_comment=False)
     else:
         pr_for_commit = await util.get_pr_for_commit(gh, sha)
         if pr_for_commit:

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -115,13 +115,13 @@ async def check_ci_status_and_approval(
                         status = "it's a success"
                     message = f"Status check is done, and {status} {emoji}."
                     if not success:
-                        if is_automerge:
-                            participants = await util.get_gh_participants(gh, pr_number)
-                        else:
-                            original_pr_number = title_match.group("pr")
-                            participants = await util.get_gh_participants(
-                                gh, original_pr_number
-                            )
+                        # if is_automerge:
+                        participants = await util.get_gh_participants(gh, pr_number)
+                        # else:
+                        #    original_pr_number = title_match.group("pr")
+                        #    participants = await util.get_gh_participants(
+                        #        gh, original_pr_number
+                        #    )
                         message = f"{participants}: {message}"
                     await util.leave_comment(
                         gh,

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -113,7 +113,8 @@ async def backport_task_asyncio(
                 gh,
                 issue_number,
                 f"""Sorry {util.get_participants(created_by, merged_by)}, I had trouble checking out the `{branch}` backport branch.
-                                Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
+                                Please retry by removing and re-adding the "needs backport to {branch}" label.
+                                Alternatively, you can backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on the command line.
                                 ```
                                 cherry_picker {commit_hash} {branch}
                                 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ git+https://github.com/python/cherry-picker.git@main#egg=cherry_picker
 aiohttp==3.8.3
 gidgethub==5.2.1
 cachetools==5.2.0
-redis==4.3.5
+redis==4.4.0
 celery==5.2.7
 sentry-sdk==1.11.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.1
 cachetools==5.2.0
 redis==4.4.0
 celery==5.2.7
-sentry-sdk==1.11.1
+sentry-sdk==1.12.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ git+https://github.com/python/cherry-picker.git@main#egg=cherry_picker
 aiohttp==3.8.3
 gidgethub==5.2.1
 cachetools==5.2.0
-redis==4.3.4
+redis==4.3.5
 celery==5.2.7
 sentry-sdk==1.11.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # cherry_picker==2.0.0
 git+https://github.com/python/cherry-picker.git@main#egg=cherry_picker
 aiohttp==3.8.3
-gidgethub==5.2.0
+gidgethub==5.2.1
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.1
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7
-sentry-sdk==1.9.9
+sentry-sdk==1.10.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.0
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7
-sentry-sdk==1.9.6
+sentry-sdk==1.9.9
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.1
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7
-sentry-sdk==1.10.1
+sentry-sdk==1.11.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # cherry_picker==2.0.0
 git+https://github.com/python/cherry-picker.git@main#egg=cherry_picker
-aiohttp==3.8.1
+aiohttp==3.8.3
 gidgethub==5.2.0
 cachetools==5.2.0
 redis==4.3.4

--- a/tests/test_check_run.py
+++ b/tests/test_check_run.py
@@ -75,7 +75,8 @@ async def test_check_run_completed_ci_passed_with_awaiting_merge_label_pr_is_mer
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert gh.put_data["sha"] == sha  # is merged
     assert gh.put_data["merge_method"] == "squash"
     assert (
@@ -278,7 +279,8 @@ async def test_check_run_completed_failure_with_awaiting_merge_label_pr_is_not_m
 
     gh = FakeGH(getitem=getitem)
     await check_run.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -350,7 +352,8 @@ async def test_check_run_completed_timed_out_with_awaiting_merge_label_pr_is_not
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
 
 


### PR DESCRIPTION
# PR Summary

Temporarily Disable Comment Notifications for Non-Automerge PRs

## Overview

This PR temporarily disables comment notifications for non-automerge PRs, referencing issue #577. It also improves error messaging for backport tasks and removes unused constants.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Bugfix       | Temporarily disable comment notifications for non-automerge PRs |
| Enhancement  | Improve error messaging for backport tasks |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `test_check_run.py`    | Commented out assertions checking for comments with reference to issue #577 |
| `check_run.py`         | Removed AUTOMERGE_TRAILER constant and modified check_ci_status_and_approval to not leave comments for miss-islington |
| `tasks.py`             | Updated error message to suggest removing and re-adding labels before manual cherry-picker usage |
| `status_change.py`     | Modified participant notification logic to always use pr_number instead of original_pr_number |

---

## Notes for Reviewers

* This is a temporary change related to issue #577
* Comment notifications are being disabled specifically for non-automerge PRs

---

## Additional Context

* Fixes issue #577
* Temporary solution until a more permanent fix is implemented