### PR TITLE
Feature implementation from commits 3e3588b..6229ce7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 coverage
-pytest==7.1.2
+pytest==7.1.3
 pytest-asyncio==0.19.0
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage
 pytest==7.1.3
-pytest-asyncio==0.19.0
+pytest-asyncio==0.20.1
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0
 codecov==2.1.12

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 coverage
-pytest==7.1.3
+pytest==7.2.0
 pytest-asyncio==0.20.1
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,5 @@ coverage
 pytest==7.1.2
 pytest-asyncio==0.19.0
 pytest-aiohttp==1.0.4
-pytest-cov==3.0.0
+pytest-cov==4.0.0
 codecov==2.1.12

--- a/miss_islington/check_run.py
+++ b/miss_islington/check_run.py
@@ -8,7 +8,6 @@ from .status_change import check_ci_status_and_approval
 router = routing.Router()
 
 TITLE_RE = re.compile(r"\[(?P<branch>\d+\.\d+)\].+?(?P<pr>\d+)\)")
-AUTOMERGE_TRAILER = "Automerge-Triggered-By"
 
 
 @router.register("check_run", action="completed")
@@ -19,7 +18,8 @@ async def check_run_completed(event, gh, *args, **kwargs):
     sha = event.data["check_run"]["head_sha"]
 
     if event.data["sender"]["login"] == "miss-islington":
-        await check_ci_status_and_approval(gh, sha, leave_comment=True)
+        # Leave comment temporarily disabled when automerge not used. See #577.
+        await check_ci_status_and_approval(gh, sha, leave_comment=False)
     else:
         pr_for_commit = await util.get_pr_for_commit(gh, sha)
         if pr_for_commit:

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -22,7 +22,8 @@ async def check_status(event, gh, *args, **kwargs):
         event.data["commit"].get("committer")
         and event.data["commit"]["committer"]["login"] == "miss-islington"
     ):
-        await check_ci_status_and_approval(gh, sha, leave_comment=True)
+        # Leave comment temporarily disabled when automerge not used. See #577.
+        await check_ci_status_and_approval(gh, sha, leave_comment=False)
     else:
         pr_for_commit = await util.get_pr_for_commit(gh, sha)
         if pr_for_commit:
@@ -106,12 +107,9 @@ async def check_ci_status_and_approval(
                 )
                 success = result["state"] == "success" and not failure
                 if leave_comment:
-                    if failure:
+                    if failure or not success:
                         emoji = "❌"
                         status = "it's a failure or timed out"
-                    elif not success:
-                        emoji = "❌"
-                        status = "it's a failure"
                     else:
                         emoji = "✅"
                         status = "it's a success"

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -100,16 +100,22 @@ async def check_ci_status_and_approval(
 
             title_match = TITLE_RE.match(normalized_pr_title)
             if title_match or is_automerge:
-                success = result["state"] == "success" and not any(
+                failure = any(
                     elem in [None, "failure", "timed_out"]
                     for elem in all_check_run_conclusions
                 )
+                success = result["state"] == "success" and not failure
                 if leave_comment:
                     if success:
                         emoji = "✅"
+                        status = "it's a success"
+                    if failure:
+                        emoji = "❌"
+                        status = "it's a failure or timed out"
                     else:
                         emoji = "❌"
-                    message = f"Status check is done, and it's a {result['state']} {emoji} ."
+                        status = "it's a failure"
+                    message = f"Status check is done, and {status} {emoji}."
                     if not success:
                         if is_automerge:
                             participants = await util.get_gh_participants(gh, pr_number)

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -106,15 +106,15 @@ async def check_ci_status_and_approval(
                 )
                 success = result["state"] == "success" and not failure
                 if leave_comment:
-                    if success:
-                        emoji = "✅"
-                        status = "it's a success"
                     if failure:
                         emoji = "❌"
                         status = "it's a failure or timed out"
-                    else:
+                    elif not success:
                         emoji = "❌"
                         status = "it's a failure"
+                    else:
+                        emoji = "✅"
+                        status = "it's a success"
                     message = f"Status check is done, and {status} {emoji}."
                     if not success:
                         if is_automerge:

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -115,13 +115,13 @@ async def check_ci_status_and_approval(
                         status = "it's a success"
                     message = f"Status check is done, and {status} {emoji}."
                     if not success:
-                        if is_automerge:
-                            participants = await util.get_gh_participants(gh, pr_number)
-                        else:
-                            original_pr_number = title_match.group("pr")
-                            participants = await util.get_gh_participants(
-                                gh, original_pr_number
-                            )
+                        # if is_automerge:
+                        participants = await util.get_gh_participants(gh, pr_number)
+                        # else:
+                        #    original_pr_number = title_match.group("pr")
+                        #    participants = await util.get_gh_participants(
+                        #        gh, original_pr_number
+                        #    )
                         message = f"{participants}: {message}"
                     await util.leave_comment(
                         gh,

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -113,7 +113,8 @@ async def backport_task_asyncio(
                 gh,
                 issue_number,
                 f"""Sorry {util.get_participants(created_by, merged_by)}, I had trouble checking out the `{branch}` backport branch.
-                                Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
+                                Please retry by removing and re-adding the "needs backport to {branch}" label.
+                                Alternatively, you can backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on the command line.
                                 ```
                                 cherry_picker {commit_hash} {branch}
                                 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # cherry_picker==2.0.0
 git+https://github.com/python/cherry-picker.git@main#egg=cherry_picker
 aiohttp==3.8.3
-gidgethub==5.2.0
+gidgethub==5.2.1
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.1
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7
-sentry-sdk==1.9.9
+sentry-sdk==1.10.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.0
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7
-sentry-sdk==1.9.6
+sentry-sdk==1.9.9
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.1
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7
-sentry-sdk==1.10.1
+sentry-sdk==1.11.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gidgethub==5.2.0
 cachetools==5.2.0
 redis==4.3.4
 celery==5.2.7
-sentry-sdk==1.9.0
+sentry-sdk==1.9.6
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # cherry_picker==2.0.0
 git+https://github.com/python/cherry-picker.git@main#egg=cherry_picker
-aiohttp==3.8.1
+aiohttp==3.8.3
 gidgethub==5.2.0
 cachetools==5.2.0
 redis==4.3.4

--- a/tests/test_check_run.py
+++ b/tests/test_check_run.py
@@ -143,7 +143,18 @@ async def test_check_run_completed_other_check_run_pending_with_awaiting_merge_l
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
     assert not hasattr(gh, "post_data")  # does not leave a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -326,7 +337,18 @@ async def test_check_run_completed_timed_out_with_awaiting_merge_label_pr_is_not
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged

--- a/tests/test_check_run.py
+++ b/tests/test_check_run.py
@@ -75,7 +75,8 @@ async def test_check_run_completed_ci_passed_with_awaiting_merge_label_pr_is_mer
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert gh.put_data["sha"] == sha  # is merged
     assert gh.put_data["merge_method"] == "squash"
     assert (
@@ -278,7 +279,8 @@ async def test_check_run_completed_failure_with_awaiting_merge_label_pr_is_not_m
 
     gh = FakeGH(getitem=getitem)
     await check_run.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -350,7 +352,8 @@ async def test_check_run_completed_timed_out_with_awaiting_merge_label_pr_is_not
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
 
 

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -129,7 +129,8 @@ async def test_ci_passed_with_awaiting_merge_label_pr_is_merged():
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "Status check is done, and it's a success ✅."
+    assert gh.post_data["body"] == expected_body
     assert gh.put_data["sha"] == sha  # is merged
     assert gh.put_data["merge_method"] == "squash"
     assert (
@@ -196,7 +197,8 @@ async def test_ci_and_check_run_passed_with_no_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "Status check is done, and it's a success ✅."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -252,7 +254,8 @@ async def test_ci_not_passed_awaiting_merge_label_pr_is_not_merged():
 
     gh = FakeGH(getitem=getitem)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -320,7 +323,8 @@ async def test_ci_passed_and_check_run_failure_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -398,7 +402,8 @@ async def test_automerge_with_check_run_failure():
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@Mariatta: Status check is done, and it's a failure or timed out ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -466,7 +471,8 @@ async def test_ci_passed_and_check_run_pending_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -1342,7 +1348,8 @@ async def test_ci_passed_automerge():
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "Status check is done, and it's a success ✅."
+    assert gh.post_data["body"] == expected_body
     assert gh.put_data["sha"] == sha  # is merged
     assert gh.put_data["merge_method"] == "squash"
     assert (

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -307,7 +307,18 @@ async def test_ci_passed_and_check_run_failure_awaiting_merge_label_pr_is_not_me
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -374,7 +385,18 @@ async def test_automerge_with_check_run_failure():
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -431,7 +453,18 @@ async def test_ci_passed_and_check_run_pending_awaiting_merge_label_pr_is_not_me
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -488,9 +521,22 @@ async def test_ci_passed_and_check_run_timed_out_awaiting_merge_label_pr_is_not_
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = ("@miss-islington and @Mariatta: Status check is done, "
+                      "and it's a failure or timed out ❌.")
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -129,8 +129,9 @@ async def test_ci_passed_with_awaiting_merge_label_pr_is_merged():
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    expected_body = "Status check is done, and it's a success ✅."
-    assert gh.post_data["body"] == expected_body
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # expected_body = "Status check is done, and it's a success ✅."
+    # assert gh.post_data["body"] == expected_body
     assert gh.put_data["sha"] == sha  # is merged
     assert gh.put_data["merge_method"] == "squash"
     assert (
@@ -197,8 +198,9 @@ async def test_ci_and_check_run_passed_with_no_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem)
     await status_change.router.dispatch(event, gh)
-    expected_body = "Status check is done, and it's a success ✅."
-    assert gh.post_data["body"] == expected_body
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # expected_body = "Status check is done, and it's a success ✅."
+    # assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -254,8 +256,9 @@ async def test_ci_not_passed_awaiting_merge_label_pr_is_not_merged():
 
     gh = FakeGH(getitem=getitem)
     await status_change.router.dispatch(event, gh)
-    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure ❌."
-    assert gh.post_data["body"] == expected_body
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure ❌."
+    # assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -323,8 +326,9 @@ async def test_ci_passed_and_check_run_failure_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
-    assert gh.post_data["body"] == expected_body
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
+    # assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -471,8 +475,9 @@ async def test_ci_passed_and_check_run_pending_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
-    assert gh.post_data["body"] == expected_body
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
+    # assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -540,9 +545,10 @@ async def test_ci_passed_and_check_run_timed_out_awaiting_merge_label_pr_is_not_
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    expected_body = ("@miss-islington and @Mariatta: Status check is done, "
-                      "and it's a failure or timed out ❌.")
-    assert gh.post_data["body"] == expected_body
+    # Leave comment temporarily disabled when automerge not used. See #577.
+    # expected_body = ("@miss-islington and @Mariatta: Status check is done, "
+    #                   "and it's a failure or timed out ❌.")
+    # assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 


### PR DESCRIPTION
# PR Summary

Disable comment posting and improve error messages

## Overview

This PR addresses issue #577 by disabling automatic comment posting in various scenarios and improving error messages. It also updates tests to accommodate these changes and refactors CI status check logic.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Enhancement  | Improved error message for users when cherry-picking fails |
| Bugfix       | Disabled comment posting to address issue #577 |
| Refactor     | Refactored CI status check logic for better failure detection |
| Test         | Updated test cases to accommodate comment posting changes |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `tasks.py`             | Improved error message for cherry-picking failures |
| `check_run.py`         | Removed AUTOMERGE_TRAILER constant and disabled comment posting |
| `status_change.py`     | Disabled comment posting and refactored CI status check logic |
| `test_check_run.py`    | Updated tests to accommodate disabled comment posting |
| `test_status_change.py`| Updated tests with mock data and disabled comment assertions |

---

## Notes for Reviewers

* Multiple test assertions related to comment posting have been temporarily disabled with references to issue #577
* The PR focuses on addressing the issue by disabling comment posting while maintaining functionality
* Tests have been updated to use more specific assertions where needed

---

## Additional Context

* Fixes issue #577
* Changes how miss-islington interacts with PRs by no longer posting comments in certain scenarios